### PR TITLE
Ruby 2.5 support

### DIFF
--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -35,7 +35,7 @@ module Mongo
     include Enumerable
     include Retryable
 
-    def_delegators :@view, :collection, :limit
+    def_delegators :@view, :collection
     def_delegators :collection, :client, :database
     def_delegators :@server, :cluster
 
@@ -239,6 +239,10 @@ module Mongo
 
     def use_limit?
       limited? && batch_size >= @remaining
+    end
+
+    def limit
+      @view.send(:limit)
     end
 
     def register

--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -4,7 +4,7 @@ require 'mongo/version'
 
 Gem::Specification.new do |s|
   s.name              = 'mongo'
-  s.version           = Mongo::VERSION
+  s.version           = Mongo::VERSION + '.4.skroutz'
   s.platform          = Gem::Platform::RUBY
 
   s.authors           = ['Tyler Brock', 'Emily Stolfo', 'Durran Jordan']


### PR DESCRIPTION
All tests pass with `bundle exec rspec`
> 3761 examples, 0 failures, 29 pending

Upon closer inspection, the following warnings were emitted:
> warning: Mongo::Cursor#limit at /usr/lib/ruby/2.5.0/forwardable.rb:157 forwarding to private method Mongo::Index::View#limit

While this is only a warning, I prefer to fix it and avoid the extra noise in our logs. (this warning is emitted every time we try to call a private method with the forwardable interface)  